### PR TITLE
Use mapped class name if it exists

### DIFF
--- a/src/main/java/malte0811/profilingremapper/nps/NPSParser.java
+++ b/src/main/java/malte0811/profilingremapper/nps/NPSParser.java
@@ -51,11 +51,12 @@ public record NPSParser(IMappingFile mappings) {
         reader.rereadBoolean(); // "collectingTwoTimeStamps", whatever that means
         int numMethods = reader.rereadInt();
         for (int i = 0; i < numMethods; ++i) {
-            final var clazz = reader.rereadUTF();
+            var clazz = reader.in().readUTF();
             var methodName = reader.in().readUTF();
             final var methodDesc = reader.in().readUTF();
             var classMappings = mappings.getClass(clazz.replace('.', '/'));
             if (classMappings != null) {
+                clazz = classMappings.getMapped();
                 // Can't use a direct lookup since that would require VVM to actually produce sensible methodDesc's
                 // instead of empty strings
                 for (var method : classMappings.getMethods()) {
@@ -65,6 +66,7 @@ public record NPSParser(IMappingFile mappings) {
                     }
                 }
             }
+            reader.out().writeUTF(clazz);
             reader.out().writeUTF(methodName);
             reader.out().writeUTF(methodDesc);
         }


### PR DESCRIPTION
This fixes NPS snapshots of Fabric instances having method names remapped, but not class names. I also verified that this doesn't break anything with a Forge TSRG. The bug wouldn't be noticeable on Forge because it uses Mojmap class names in production anyway.